### PR TITLE
ci: add E2E tests with Playwright browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,48 @@ jobs:
       - name: Run mypy
         run: uv run mypy src/
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: uv run playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: uv run playwright install-deps chromium
+
+      - name: Run E2E tests
+        run: |
+          uv run pytest tests/ -m e2e -v --browser chromium
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test, type-check]
+    needs: [lint, test, type-check, e2e]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Add separate `e2e` job for running E2E tests in CI
- Cache Playwright browsers using `actions/cache@v4`
- Install only Chromium browser to minimize CI time
- Build job now depends on E2E tests passing

## Changes

- Added new `e2e` job to `.github/workflows/ci.yml`
- Playwright browsers are cached based on pyproject.toml hash
- System deps installed separately when cache is hit

## Test plan

- [x] E2E tests run successfully in CI
- [x] Playwright browser caching works
- [x] Build job waits for E2E job

Closes #5