### PR TITLE
feat: implement publish() method for PageAdminPage

### DIFF
--- a/src/wagtail_scenario_test/page_objects/wagtail_admin.py
+++ b/src/wagtail_scenario_test/page_objects/wagtail_admin.py
@@ -575,6 +575,43 @@ class PageAdminPage(WagtailAdminPage):
         self.wait_for_navigation()
 
     # =========================================================================
+    # Page Publishing
+    # =========================================================================
+
+    def publish(self, page_id: int | None = None) -> None:
+        """
+        Publish a page.
+
+        If page_id is provided, navigates to the edit page first.
+        Otherwise, assumes we are already on the page edit screen.
+
+        In Wagtail, the Publish button is in a dropdown menu at the bottom
+        of the page editor. This method opens the dropdown and clicks Publish.
+
+        Args:
+            page_id: Optional page ID to publish. If provided, navigates to
+                the edit page first. If None, assumes already on edit page.
+
+        Example:
+            # Publish a specific page by ID
+            page_admin.publish(page_id=5)
+
+            # Or navigate to edit page first, then publish
+            page_admin.edit_page(5)
+            # ... make some edits ...
+            page_admin.publish()
+        """
+        if page_id is not None:
+            self.edit_page(page_id)
+
+        # Publish is in the "More actions" dropdown menu at the bottom of the editor
+        # This dropdown contains Save draft, Publish, and other save-related actions
+        # Note: The "Actions" dropdown (at the top) contains Delete, Copy, Move
+        self.page.get_by_role("button", name="More actions").click()
+        self.page.get_by_role("button", name="Publish").click()
+        self.wait_for_navigation()
+
+    # =========================================================================
     # Page Creation
     # =========================================================================
 

--- a/tests/unit/test_page_admin.py
+++ b/tests/unit/test_page_admin.py
@@ -84,6 +84,46 @@ class TestPageAdminPageEditPage:
         mock_page.wait_for_load_state.assert_called()
 
 
+class TestPageAdminPagePublish:
+    """Tests for PageAdminPage publish method."""
+
+    def test_publish_with_page_id(self, mock_page, test_url):
+        """publish with page_id should navigate to edit page and click Publish."""
+        page_admin = PageAdminPage(mock_page, test_url)
+
+        page_admin.publish(page_id=5)
+
+        # Should navigate to edit page first
+        mock_page.goto.assert_called_with(f"{test_url}/admin/pages/5/edit/")
+
+        # Should open "More actions" dropdown and click Publish button
+        mock_page.get_by_role.assert_any_call("button", name="More actions")
+        mock_page.get_by_role.assert_any_call("button", name="Publish")
+
+    def test_publish_without_page_id(self, mock_page, test_url):
+        """publish without page_id should not navigate, just click Publish."""
+        page_admin = PageAdminPage(mock_page, test_url)
+
+        page_admin.publish()
+
+        # Should NOT navigate (no goto call for edit page)
+        for call in mock_page.goto.call_args_list:
+            assert "/edit/" not in str(call)
+
+        # Should open "More actions" dropdown and click Publish button
+        mock_page.get_by_role.assert_any_call("button", name="More actions")
+        mock_page.get_by_role.assert_any_call("button", name="Publish")
+
+    def test_publish_waits_for_navigation(self, mock_page, test_url):
+        """publish should wait for navigation to complete."""
+        page_admin = PageAdminPage(mock_page, test_url)
+
+        page_admin.publish(page_id=10)
+
+        # Should call wait_for_load_state (from wait_for_navigation)
+        mock_page.wait_for_load_state.assert_called()
+
+
 class TestPageAdminPageDeletePage:
     """Tests for PageAdminPage delete_page method."""
 


### PR DESCRIPTION
## Related Issue
Closes #23

## Summary
Implement `publish()` method for `PageAdminPage` to publish pages from the page editor.

## Changes
- Added `publish(page_id=None)` method to `PageAdminPage` class
  - Navigates to edit page if `page_id` is provided
  - Opens the "More actions" dropdown and clicks the "Publish" button
  - Waits for navigation after publishing
- Added unit tests for `publish()` method (3 tests)
- Added E2E tests for publishing draft pages (2 tests)

## API Usage
```python
# Publish a specific page by ID
page_admin.publish(page_id=5)

# Or navigate to edit page first, then publish
page_admin.edit_page(5)
# ... make some edits ...
page_admin.publish()

# Via facade
admin = WagtailAdmin(page, base_url)
admin.pages().publish(page_id=5)
```

## Testing
- [x] Unit tests passed (205 tests)
- [x] E2E tests passed (2 new tests)
- [x] Type check passed (mypy)
- [x] Lint passed (ruff)

## Demo
GIFs available in `test-results/` directory:
- `test_publish_draft_page` - Create draft page, then publish

![video](https://github.com/user-attachments/assets/aa45fa9d-dbb3-4697-a1fa-0f0579fc1980)


- `test_publish_from_edit_page` - Navigate to edit page, then publish

![video](https://github.com/user-attachments/assets/9748a1ce-606d-4d5b-98e8-3e5b77256a78)

