### PR TITLE
feat: implement unpublish() method for PageAdminPage

### DIFF
--- a/src/wagtail_scenario_test/page_objects/wagtail_admin.py
+++ b/src/wagtail_scenario_test/page_objects/wagtail_admin.py
@@ -611,6 +611,46 @@ class PageAdminPage(WagtailAdminPage):
         self.page.get_by_role("button", name="Publish").click()
         self.wait_for_navigation()
 
+    def unpublish(self, page_id: int | None = None, confirm: bool = True) -> None:
+        """
+        Unpublish a live page.
+
+        If page_id is provided, navigates to the edit page first.
+        Otherwise, assumes we are already on the page edit screen.
+
+        In Wagtail, the Unpublish action is in the "Actions" dropdown menu
+        at the top of the page editor (same dropdown as Delete, Copy, Move).
+
+        Args:
+            page_id: Optional page ID to unpublish. If provided, navigates to
+                the edit page first. If None, assumes already on edit page.
+            confirm: Whether to confirm the unpublish action (default True)
+
+        Example:
+            # Unpublish a specific page by ID
+            page_admin.unpublish(page_id=5)
+
+            # Or navigate to edit page first, then unpublish
+            page_admin.edit_page(5)
+            page_admin.unpublish()
+
+            # Go to confirmation page without confirming
+            page_admin.unpublish(page_id=5, confirm=False)
+        """
+        if page_id is not None:
+            self.edit_page(page_id)
+
+        # Unpublish is in the "Actions" dropdown (same as Delete, Copy, Move)
+        # This is different from the "More actions" dropdown which has Publish
+        self.page.get_by_role("button", name="Actions", exact=True).click()
+
+        # Click the Unpublish link in the dropdown
+        self.page.get_by_role("link", name="Unpublish", exact=True).click()
+
+        if confirm:
+            self.page.get_by_role("button", name="Yes, unpublish").click()
+        self.wait_for_navigation()
+
     # =========================================================================
     # Page Creation
     # =========================================================================

--- a/tests/unit/test_page_admin.py
+++ b/tests/unit/test_page_admin.py
@@ -124,6 +124,65 @@ class TestPageAdminPagePublish:
         mock_page.wait_for_load_state.assert_called()
 
 
+class TestPageAdminPageUnpublish:
+    """Tests for PageAdminPage unpublish method."""
+
+    def test_unpublish_with_page_id_and_confirm(self, mock_page, test_url):
+        """unpublish with page_id should navigate, open dropdown, and confirm."""
+        page_admin = PageAdminPage(mock_page, test_url)
+
+        page_admin.unpublish(page_id=5)
+
+        # Should navigate to edit page first
+        mock_page.goto.assert_called_with(f"{test_url}/admin/pages/5/edit/")
+
+        # Should open "Actions" dropdown (exact match)
+        mock_page.get_by_role.assert_any_call("button", name="Actions", exact=True)
+
+        # Should click Unpublish link and Yes, unpublish button
+        mock_page.get_by_role.assert_any_call("link", name="Unpublish", exact=True)
+        mock_page.get_by_role.assert_any_call("button", name="Yes, unpublish")
+
+    def test_unpublish_without_page_id(self, mock_page, test_url):
+        """unpublish without page_id should not navigate, just unpublish."""
+        page_admin = PageAdminPage(mock_page, test_url)
+
+        page_admin.unpublish()
+
+        # Should NOT navigate (no goto call for edit page)
+        for call in mock_page.goto.call_args_list:
+            assert "/edit/" not in str(call)
+
+        # Should open "Actions" dropdown and click Unpublish link
+        mock_page.get_by_role.assert_any_call("button", name="Actions", exact=True)
+        mock_page.get_by_role.assert_any_call("link", name="Unpublish", exact=True)
+
+    def test_unpublish_without_confirm(self, mock_page, test_url):
+        """unpublish with confirm=False should not click Yes, unpublish."""
+        page_admin = PageAdminPage(mock_page, test_url)
+
+        page_admin.unpublish(page_id=5, confirm=False)
+
+        # Should open "Actions" dropdown and click Unpublish link
+        mock_page.get_by_role.assert_any_call("button", name="Actions", exact=True)
+        mock_page.get_by_role.assert_any_call("link", name="Unpublish", exact=True)
+
+        # Should NOT call Yes, unpublish
+        for call in mock_page.get_by_role.call_args_list:
+            args, kwargs = call
+            if args[0] == "button" and kwargs.get("name") == "Yes, unpublish":
+                raise AssertionError("Yes, unpublish should not be clicked")
+
+    def test_unpublish_waits_for_navigation(self, mock_page, test_url):
+        """unpublish should wait for navigation to complete."""
+        page_admin = PageAdminPage(mock_page, test_url)
+
+        page_admin.unpublish(page_id=10)
+
+        # Should call wait_for_load_state (from wait_for_navigation)
+        mock_page.wait_for_load_state.assert_called()
+
+
 class TestPageAdminPageDeletePage:
     """Tests for PageAdminPage delete_page method."""
 


### PR DESCRIPTION
## Related Issue
Closes #24

## Summary
Implement `unpublish()` method for `PageAdminPage` to unpublish live pages from the page editor.

## Changes
- Added `unpublish(page_id=None, confirm=True)` method to `PageAdminPage` class
  - Navigates to edit page if `page_id` is provided
  - Opens the "Actions" dropdown (same as delete_page)
  - Clicks the "Unpublish" link
  - Confirms with "Yes, unpublish" button if `confirm=True`
- Added unit tests (4 new tests)
- Added E2E tests (2 new tests)

## API Usage
```python
# Unpublish a specific page by ID
page_admin.unpublish(page_id=5)

# Or navigate to edit page first, then unpublish
page_admin.edit_page(5)
page_admin.unpublish()

# Go to confirmation page without confirming
page_admin.unpublish(page_id=5, confirm=False)

# Via facade
admin = WagtailAdmin(page, base_url)
admin.pages().unpublish(page_id=5)
```

## Testing
- [x] Unit tests passed (209 tests)
- [x] E2E tests passed (2 new tests)
- [x] Type check passed (mypy)
- [x] Lint passed (ruff)

## Demo
GIFs available in `test-results/` directory:
- `test_unpublish_live_page` - Create and publish page, then unpublish

[video.webm](https://github.com/user-attachments/assets/496a5357-42e1-4b93-aaa7-d90d25d96ae9)


- `test_unpublish_from_edit_page` - Navigate to edit page, then unpublish

[video.webm](https://github.com/user-attachments/assets/9c44e3db-3903-46e5-9f31-4863bab8a7d7)

