### PR TITLE
chore: fix deprecation warnings and enable skipped test

### DIFF
--- a/src/wagtail_scenario_test/page_objects/wagtail_admin.py
+++ b/src/wagtail_scenario_test/page_objects/wagtail_admin.py
@@ -57,11 +57,9 @@ class WagtailAdminPage(BasePage):
         self.page.wait_for_url(f"**{self.ADMIN_ROOT}**")
 
     def logout(self) -> None:
-        """Log out of Wagtail admin by clicking the logout link in account menu."""
-        # Click account button/avatar to open dropdown
-        self.page.locator("[data-w-dropdown-target='toggle']").first.click()
-        # Click logout link
-        self.page.get_by_role("link", name="Log out").click()
+        """Log out of Wagtail admin by navigating to the logout URL."""
+        self.goto(self.LOGOUT_URL)
+        self.wait_for_navigation()
 
     def is_logged_in(self) -> bool:
         """Check if currently logged in."""

--- a/src/wagtail_scenario_test/utils/factories.py
+++ b/src/wagtail_scenario_test/utils/factories.py
@@ -32,11 +32,19 @@ class WagtailUserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = get_user_model()
         django_get_or_create = ("username",)
+        skip_postgeneration_save = True
 
     username = factory.Sequence(lambda n: f"user{n}")
     email = factory.LazyAttribute(lambda obj: f"{obj.username}@example.com")
-    password = factory.PostGenerationMethodCall("set_password", "password123")
     is_active = True
+
+    @factory.post_generation
+    def password(self, create: bool, extracted: str | None, **kwargs: object) -> None:
+        """Set password after user creation."""
+        password = extracted or "password123"
+        self.set_password(password)  # type: ignore[attr-defined]
+        if create:
+            self.save()  # type: ignore[attr-defined]
 
 
 class WagtailSuperUserFactory(WagtailUserFactory):

--- a/tests/e2e/test_e2e_wagtail_admin.py
+++ b/tests/e2e/test_e2e_wagtail_admin.py
@@ -20,7 +20,6 @@ class TestWagtailAdminE2E:
         # Should return a boolean (True when on admin pages, not login)
         assert isinstance(result, bool)
 
-    @pytest.mark.skip(reason="Logout selector varies by Wagtail version")
     def test_logout(self, authenticated_page, server_url):
         """Test logout navigates to logout page."""
         admin = WagtailAdmin(authenticated_page, server_url)

--- a/tests/unit/test_facade.py
+++ b/tests/unit/test_facade.py
@@ -114,10 +114,10 @@ class TestWagtailAdminDelegation:
 
         admin.logout()
 
-        # Should click account dropdown toggle
-        mock_page.locator.assert_called_with("[data-w-dropdown-target='toggle']")
-        # Should click logout link
-        mock_page.get_by_role.assert_called_with("link", name="Log out")
+        # Should navigate to logout URL
+        mock_page.goto.assert_called_with(f"{test_url}/admin/logout/")
+        # Should wait for navigation
+        mock_page.wait_for_load_state.assert_called()
 
     def test_assert_success_message(self, mock_page, test_url, mock_playwright_expect):
         """assert_success_message should delegate to admin page."""

--- a/tests/unit/test_wagtail_admin.py
+++ b/tests/unit/test_wagtail_admin.py
@@ -43,15 +43,15 @@ class TestWagtailAdminPageAuth:
         mock_page.wait_for_url.assert_called_once_with("**/admin/**")
 
     def test_logout(self, mock_page, test_url):
-        """logout should click account menu and logout link."""
+        """logout should navigate to logout URL."""
         admin = WagtailAdminPage(mock_page, test_url)
 
         admin.logout()
 
-        # Should click account dropdown toggle
-        mock_page.locator.assert_called_with("[data-w-dropdown-target='toggle']")
-        # Should click logout link
-        mock_page.get_by_role.assert_called_with("link", name="Log out")
+        # Should navigate to logout URL
+        mock_page.goto.assert_called_with(f"{test_url}/admin/logout/")
+        # Should wait for navigation
+        mock_page.wait_for_load_state.assert_called()
 
     def test_is_logged_in_returns_true(self, mock_page, test_url):
         """is_logged_in should return True when on admin page."""


### PR DESCRIPTION
## Summary
Fix test warnings and enable previously skipped test.

## Changes

### 1. Fix factory_boy deprecation warning
- Changed from `PostGenerationMethodCall` to `@factory.post_generation` decorator
- Added `skip_postgeneration_save=True` to Meta class
- Explicitly call `save()` after setting password

### 2. Fix logout() and enable skipped test
- Changed `logout()` to navigate directly to `/admin/logout/` URL
- This is more reliable than clicking dropdown which varies by Wagtail version
- Removed `@pytest.mark.skip` from `test_logout`
- Updated unit tests to match new implementation

## Testing
- [x] All 244 tests pass
- [x] No warnings
- [x] No skipped tests
- [x] mypy/ruff pass