### PR TITLE
feat: implement preview_url() method for PageAdminPage

### DIFF
--- a/src/wagtail_scenario_test/page_objects/wagtail_admin.py
+++ b/src/wagtail_scenario_test/page_objects/wagtail_admin.py
@@ -518,6 +518,18 @@ class PageAdminPage(WagtailAdminPage):
         """
         return f"/admin/pages/{page_id}/delete/"
 
+    def preview_url(self, page_id: int) -> str:
+        """
+        Return the preview URL for a page.
+
+        This returns the URL for viewing a page preview within the Wagtail admin.
+        The preview is displayed in an iframe on the edit page.
+
+        Args:
+            page_id: The page ID to preview
+        """
+        return f"/admin/pages/{page_id}/edit/preview/"
+
     # =========================================================================
     # Page Navigation
     # =========================================================================

--- a/tests/unit/test_page_admin.py
+++ b/tests/unit/test_page_admin.py
@@ -62,6 +62,14 @@ class TestPageAdminPageUrls:
 
         assert url == "/admin/pages/42/delete/"
 
+    def test_preview_url(self, mock_page, test_url):
+        """preview_url should return correct URL."""
+        page_admin = PageAdminPage(mock_page, test_url)
+
+        url = page_admin.preview_url(page_id=42)
+
+        assert url == "/admin/pages/42/edit/preview/"
+
 
 class TestPageAdminPageEditPage:
     """Tests for PageAdminPage edit_page method."""


### PR DESCRIPTION
## Related Issue
Closes #26

## Summary
Implement `preview_url()` method to get the preview URL for a page.

## Changes
- Added `preview_url(page_id)` method to `PageAdminPage` class
- Returns `/admin/pages/{page_id}/edit/preview/`
- Added unit test

## API Usage
```python
page_admin = PageAdminPage(page, base_url)
url = page_admin.preview_url(page_id=5)
# Returns: "/admin/pages/5/edit/preview/"
```

## Testing
- [x] Unit tests passed
- [x] Type check passed (mypy)
- [x] Lint passed (ruff)

## Note
This is a simple URL helper method. E2E testing would require navigating to this URL
and interacting with the preview iframe, which will be covered in Issue #30 (visit_preview).