### PR TITLE
feat: implement get_live_url() method for PageAdminPage

### DIFF
--- a/src/wagtail_scenario_test/page_objects/wagtail_admin.py
+++ b/src/wagtail_scenario_test/page_objects/wagtail_admin.py
@@ -530,6 +530,30 @@ class PageAdminPage(WagtailAdminPage):
         """
         return f"/admin/pages/{page_id}/edit/preview/"
 
+    def get_live_url(self) -> str | None:
+        """
+        Get the live URL of the current page from the editor.
+
+        Must be on a page edit screen. Returns the href of the "Live" status link,
+        or None if the page is not published or has no routable URL.
+
+        In Wagtail 7+, published pages show a "Live" status link in the page header
+        that links to the live URL.
+
+        Returns:
+            The live URL of the page, or None if not available.
+
+        Example:
+            page_admin.edit_page(5)
+            url = page_admin.get_live_url()
+            # Returns something like "/my-page/" or None if not published
+        """
+        # In Wagtail 7+, the "Live" status link points to the live URL
+        link = self.page.get_by_role("link", name="Live")
+        if link.count() == 0:
+            return None
+        return link.get_attribute("href")
+
     # =========================================================================
     # Page Navigation
     # =========================================================================

--- a/tests/testapp/templates/testapp/test_page.html
+++ b/tests/testapp/templates/testapp/test_page.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ page.title }}</title>
+</head>
+<body>
+    <h1>{{ page.title }}</h1>
+    {% if page.subtitle %}<h2>{{ page.subtitle }}</h2>{% endif %}
+    {% if page.body %}<div>{{ page.body }}</div>{% endif %}
+</body>
+</html>

--- a/tests/unit/test_page_admin.py
+++ b/tests/unit/test_page_admin.py
@@ -71,6 +71,32 @@ class TestPageAdminPageUrls:
         assert url == "/admin/pages/42/edit/preview/"
 
 
+class TestPageAdminPageGetLiveUrl:
+    """Tests for PageAdminPage get_live_url method."""
+
+    def test_get_live_url_returns_href(self, mock_page, test_url):
+        """get_live_url should return href when Live status link exists."""
+        mock_link = mock_page.get_by_role.return_value
+        mock_link.count.return_value = 1
+        mock_link.get_attribute.return_value = "/my-page/"
+
+        page_admin = PageAdminPage(mock_page, test_url)
+        url = page_admin.get_live_url()
+
+        mock_page.get_by_role.assert_called_with("link", name="Live")
+        assert url == "/my-page/"
+
+    def test_get_live_url_returns_none_when_not_found(self, mock_page, test_url):
+        """get_live_url should return None when Live status link not found."""
+        mock_link = mock_page.get_by_role.return_value
+        mock_link.count.return_value = 0
+
+        page_admin = PageAdminPage(mock_page, test_url)
+        url = page_admin.get_live_url()
+
+        assert url is None
+
+
 class TestPageAdminPageEditPage:
     """Tests for PageAdminPage edit_page method."""
 


### PR DESCRIPTION
## Summary

- Add `get_live_url()` method to `PageAdminPage` to extract the live URL from the "Live" status link in Wagtail 7+ page editor
- Returns `None` if the page is not published or has no routable URL
- Add template for TestPage to enable proper URL routing in E2E tests

## Test plan

- [x] Unit tests for get_live_url() (returns href when Live link exists, returns None when not found)
- [x] E2E tests for published pages (returns URL containing slug)
- [x] E2E tests for draft pages (returns None)
- [x] All quality checks pass (ruff, mypy)
- [x] All 212 unit tests pass

Closes #27