### PR TITLE
feat: move home_page fixture to library

### DIFF
--- a/tests/e2e/test_e2e_page_admin.py
+++ b/tests/e2e/test_e2e_page_admin.py
@@ -1,30 +1,8 @@
 """E2E tests for PageAdminPage."""
 
 import pytest
-from wagtail.models import Page
 
 from wagtail_scenario_test import PageAdminPage
-
-
-@pytest.fixture
-def home_page(db, wagtail_site):
-    """Get or create a home page under the root page."""
-    root = Page.objects.get(depth=1)
-    # Check if a page already exists under root
-    home = root.get_children().first()
-    if home is None:
-        # Create a simple home page
-        home = Page(title="Home", slug="home")
-        root.add_child(instance=home)
-    # Make sure the TestPage model is allowed as a child
-    # by returning a page that can have TestPage children
-    return home
-
-
-@pytest.fixture
-def root_page(db, wagtail_site):
-    """Get the root page for creating test pages."""
-    return Page.objects.get(depth=1)
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -63,6 +63,38 @@ class TestWagtailSiteFixture:
 
 
 @pytest.mark.django_db
+class TestHomePageFixture:
+    """Tests for home_page fixture."""
+
+    def test_returns_page(self, home_page):
+        """home_page should return a Page instance."""
+        from wagtail.models import Page
+
+        assert isinstance(home_page, Page)
+
+    def test_page_is_child_of_root(self, home_page):
+        """home_page should be a child of root page."""
+        assert home_page.depth == 2
+
+    def test_creates_home_if_not_exists(self, home_page):
+        """home_page should create home page if not exists."""
+        assert home_page.title == "Home"
+        assert home_page.slug == "home"
+
+    def test_returns_existing_page_if_exists(self, wagtail_site, home_page):
+        """home_page should return existing page if one exists under root."""
+        from wagtail.models import Page
+
+        # Get root and check children
+        root = Page.objects.get(depth=1)
+        children = root.get_children()
+
+        # Should only have one child (the home page)
+        assert children.count() >= 1
+        assert home_page in children
+
+
+@pytest.mark.django_db
 class TestAdminUserE2EFixture:
     """Tests for admin_user_e2e fixture."""
 


### PR DESCRIPTION
## Summary
- Add `home_page` fixture to library (`src/wagtail_scenario_test/fixtures/__init__.py`)
- Remove duplicate fixture from test file
- Add unit tests for the fixture

## Changes
- **src/wagtail_scenario_test/fixtures/__init__.py**: Added `home_page` fixture that gets or creates a home page under the site root, providing a parent page for test page creation
- **tests/e2e/test_e2e_page_admin.py**: Removed duplicate `home_page` fixture (now using library fixture)
- **tests/unit/test_fixtures.py**: Added 4 unit tests for the fixture

## Test plan
- [x] Unit tests pass (`tests/unit/test_fixtures.py`)
- [x] E2E tests pass (verified with `test_create_child_page_as_draft`)
- [x] Quality checks pass (ruff check, ruff format, mypy)

Closes #44