### PR TITLE
feat: add test_page fixture

### DIFF
--- a/src/wagtail_scenario_test/fixtures/__init__.py
+++ b/src/wagtail_scenario_test/fixtures/__init__.py
@@ -9,6 +9,7 @@ Available fixtures:
     - server_url: Base URL of the live test server
     - wagtail_site: Creates a Wagtail site with root page
     - home_page: Gets or creates a home page under site root
+    - test_page: Creates a test page under home_page
     - admin_credentials: Returns default admin credentials
     - admin_user_e2e: Creates an admin user for E2E testing
     - authenticated_page: Playwright page logged into Wagtail admin
@@ -138,6 +139,37 @@ def home_page(db, wagtail_site):
         home = Page(title="Home", slug="home")
         root.add_child(instance=home)
     return home
+
+
+@pytest.fixture
+def test_page(db, home_page):
+    """
+    Create a test page under home_page.
+
+    This fixture provides a page that can be used as a target for
+    page operations (edit, delete, publish, etc.) in tests.
+
+    Args:
+        db: pytest-django db fixture
+        home_page: Parent page for the test page
+
+    Returns:
+        Page: A test page under home_page
+
+    Example:
+        def test_edit_page(authenticated_page, server_url, test_page):
+            page_admin = PageAdminPage(authenticated_page, server_url)
+            page_admin.edit_page(test_page.id)
+            # Now on edit page for test_page
+    """
+    from wagtail.models import Page
+
+    page = Page(
+        title="Test Page",
+        slug="test-page",
+    )
+    home_page.add_child(instance=page)
+    return page
 
 
 @pytest.fixture

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -95,6 +95,31 @@ class TestHomePageFixture:
 
 
 @pytest.mark.django_db
+class TestTestPageFixture:
+    """Tests for test_page fixture."""
+
+    def test_returns_page(self, test_page):
+        """test_page should return a Page instance."""
+        from wagtail.models import Page
+
+        assert isinstance(test_page, Page)
+
+    def test_page_is_child_of_home(self, test_page):
+        """test_page should be a child of home page (depth=3)."""
+        assert test_page.depth == 3
+
+    def test_has_correct_title(self, test_page):
+        """test_page should have correct title."""
+        assert test_page.title == "Test Page"
+        assert test_page.slug == "test-page"
+
+    def test_parent_is_home_page(self, test_page, home_page):
+        """test_page should be a child of home_page."""
+        parent = test_page.get_parent()
+        assert parent.id == home_page.id
+
+
+@pytest.mark.django_db
 class TestAdminUserE2EFixture:
     """Tests for admin_user_e2e fixture."""
 


### PR DESCRIPTION
## Summary
- Add `test_page` fixture to library (`src/wagtail_scenario_test/fixtures/__init__.py`)
- Creates a test page under `home_page` for page operations (edit, delete, publish, etc.)

## Changes
- **src/wagtail_scenario_test/fixtures/__init__.py**: Added `test_page` fixture that creates a page under home_page
- **tests/unit/test_fixtures.py**: Added 4 unit tests for the fixture

## Test plan
- [x] Unit tests pass (28 tests including 4 new ones)
- [x] Quality checks pass (ruff check, ruff format, mypy)

Closes #45