### PR TITLE
fix: use Wagtail 5.0+ compatible migration dependency

### DIFF
--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('wagtailcore', '0094_alter_page_locale'),
+        ('wagtailcore', '0083_workflowcontenttype'),
     ]
 
     operations = [

--- a/tests/testapp/migrations/0002_streamfieldpage.py
+++ b/tests/testapp/migrations/0002_streamfieldpage.py
@@ -9,7 +9,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('testapp', '0001_initial'),
-        ('wagtailcore', '0096_referenceindex_referenceindex_source_object_and_more'),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary

Fixes CI failures caused by testapp migrations depending on wagtailcore migrations that don't exist in all supported Wagtail versions.

- `0001_initial.py`: Changed dependency from `0094_alter_page_locale` (Wagtail 7+) to `0083_workflowcontenttype` (Wagtail 5.0+)
- `0002_streamfieldpage.py`: Removed explicit wagtailcore dependency since it's already inherited via `0001_initial`

## Context

PR #64 was merged with migrations generated on Wagtail 7.2, causing test failures on Wagtail 6.4 and 7.0 due to missing migration dependencies.

## Test plan

- [ ] CI passes for all Wagtail versions (6.4, 7.0, 7.2)
- [ ] All unit tests pass
- [ ] All E2E tests pass