### PR TITLE
feat: add streamfield() method to PageAdminPage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,3 @@ python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
-
-[tool.uv.workspace]
-members = [
-    "demo",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,8 @@ python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
+
+[tool.uv.workspace]
+members = [
+    "demo",
+]

--- a/src/wagtail_scenario_test/page_objects/wagtail_admin.py
+++ b/src/wagtail_scenario_test/page_objects/wagtail_admin.py
@@ -852,6 +852,31 @@ class PageAdminPage(WagtailAdminPage):
         slug = re.sub(r"-+", "-", slug)
         return slug.strip("-")
 
+    # =========================================================================
+    # StreamField Helper
+    # =========================================================================
+
+    def streamfield(self, field_name: str = "body") -> StreamFieldHelper:
+        """
+        Get a StreamFieldHelper for manipulating StreamField blocks.
+
+        Must be called while on a page edit screen.
+
+        Args:
+            field_name: The name of the StreamField (default: "body")
+
+        Returns:
+            StreamFieldHelper for the specified field
+
+        Example:
+            page_admin = PageAdminPage(page, base_url)
+            page_admin.edit_page(5)
+            sf = page_admin.streamfield("body")
+            sf.add_block("Heading")
+            sf.block(0).fill("Hello World")
+        """
+        return StreamFieldHelper(self.page, field_name)
+
 
 class BlockPath:
     """

--- a/tests/unit/test_page_admin.py
+++ b/tests/unit/test_page_admin.py
@@ -461,3 +461,37 @@ class TestPageAdminPageGenerateSlug:
         page_admin = PageAdminPage(mock_page, test_url)
 
         assert page_admin._generate_slug("hello_world") == "hello-world"
+
+
+class TestPageAdminPageStreamfield:
+    """Tests for PageAdminPage streamfield method."""
+
+    def test_streamfield_returns_helper(self, mock_page, test_url):
+        """streamfield should return a StreamFieldHelper instance."""
+        from wagtail_scenario_test.page_objects.wagtail_admin import StreamFieldHelper
+
+        page_admin = PageAdminPage(mock_page, test_url)
+        sf = page_admin.streamfield("body")
+
+        assert isinstance(sf, StreamFieldHelper)
+
+    def test_streamfield_default_field_name(self, mock_page, test_url):
+        """streamfield should use 'body' as default field name."""
+        page_admin = PageAdminPage(mock_page, test_url)
+        sf = page_admin.streamfield()
+
+        assert sf.field_name == "body"
+
+    def test_streamfield_with_custom_field_name(self, mock_page, test_url):
+        """streamfield should accept custom field name."""
+        page_admin = PageAdminPage(mock_page, test_url)
+        sf = page_admin.streamfield("content")
+
+        assert sf.field_name == "content"
+
+    def test_streamfield_uses_same_page(self, mock_page, test_url):
+        """streamfield should pass the same Playwright page to helper."""
+        page_admin = PageAdminPage(mock_page, test_url)
+        sf = page_admin.streamfield("body")
+
+        assert sf.page is mock_page


### PR DESCRIPTION
## Summary
Add `streamfield()` method to `PageAdminPage` for easy access to `StreamFieldHelper` from the facade pattern.

## Changes
- Add `streamfield(field_name="body")` method to `PageAdminPage`
- Returns `StreamFieldHelper` instance

## Usage
```python
admin = WagtailAdmin(page, server_url)
page_admin = admin.pages()
page_admin.edit_page(5)
sf = page_admin.streamfield("body")
sf.add_block("Heading")
sf.block(0).fill("Hello World")
```

Closes #86